### PR TITLE
Delete .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-.git*
-npm-debug.log


### PR DESCRIPTION
From npm

> By default, the following paths and files are ignored, so there’s no need to add them to .npmignore explicitly:
```
.*.swp
._*
.DS_Store
.git
.hg
.npmrc
.lock-wscript
.svn
.wafpickle-*
config.gypi
CVS
npm-debug.log
```